### PR TITLE
Fix linked list management

### DIFF
--- a/Manager/Funkcje.c
+++ b/Manager/Funkcje.c
@@ -3,44 +3,44 @@
 #endif
 #include <stdio.h>
 #include <stdlib.h>
-#include<conio.h>
-#include <windows.h>
+#include <curses.h>
 #include "Struktury.h"
 
-
-void zaladujNazwyPlikowDoListy(nazwyPlikow** pHead,char* buf) {
-	if (*pHead) {
-		nazwyPlikow* current = malloc(sizeof(nazwyPlikow));
-		current->tab = buf;
-		current->next = (*pHead);
-		*pHead = current;
-	}
+void zaladujNazwyPlikowDoListy(nazwyPlikow **pHead, char *buf)
+{
+	nazwyPlikow *current = malloc(sizeof(nazwyPlikow));
+	current->tab = buf;
+	current->next = (*pHead);
+	*pHead = current;
 }
 
-void pobierzNazwyPlikow(nazwyPlikow** pHead) {
-	FILE* plik = fopen("NazwyPilkow.txt","r");
-	if (plik) {
+void pobierzNazwyPlikow(nazwyPlikow **pHead)
+{
+	FILE *plik = fopen("NazwyPilkow.txt", "r");
+	if (plik)
+	{
 		const int size = 20;
-		char buf[20] = { 0 };
-		while (!feof(plik)) {
+		char buf[20] = {0};
+		while (!feof(plik))
+		{
 			fgets(buf, size, plik);
+			printf("%p, %p\n", pHead, *pHead);
 			//printf("%s\n", buf);
-			zaladujNazwyPlikowDoListy(&pHead,buf);			
+			zaladujNazwyPlikowDoListy(pHead, buf);
 		}
 		fclose(plik);
 	}
 }
 
-
-
-
-void pokaz(nazwyPlikow* l) {
-	if (l != NULL) {
+void pokaz(nazwyPlikow *l)
+{
+	if (l != NULL)
+	{
 		printf("%s ", l->tab);
 		pokaz(l->next);
 	}
-	else {
+	else
+	{
 		printf("pHead jest NULLEM :(\n");
 	}
 }
-


### PR DESCRIPTION
You have to properly handle the char-string **memory allocation**. Now you just save a pointer to `buf` which is a local variable and **is freed** after leaving `zaladujNazwyPlikowDoListy`. I also changed the `windows.h` and `conio.h` to `curses.h` because both are not present on ubuntu. Feel free to change it back. It does not change much because none of them is in use.